### PR TITLE
[LoopUnroll] Capitalize and punctuate debug messages

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -829,7 +829,7 @@ shouldPragmaUnroll(Loop *L, const PragmaInfo &PInfo,
     // INT_MAX, Block full unrolling at a reasonable limit so that the compiler
     // doesn't hang trying to unroll the loop. See PR77842
     if (TripCount > PragmaUnrollFullMaxIterations) {
-      LLVM_DEBUG(dbgs().indent(3) << "Won't unroll; trip count is too large\n");
+      LLVM_DEBUG(dbgs().indent(3) << "Won't unroll; trip count is too large.\n");
       return std::nullopt;
     }
 
@@ -882,8 +882,8 @@ shouldPartialUnroll(const unsigned LoopSize, const unsigned TripCount,
     return std::nullopt;
 
   if (!UP.Partial) {
-    LLVM_DEBUG(dbgs().indent(3) << "will not try to unroll partially because "
-                                << "-unroll-allow-partial not given\n");
+    LLVM_DEBUG(dbgs().indent(3) << "Will not try to unroll partially because "
+                                << "-unroll-allow-partial not given.\n");
     return 0;
   }
   unsigned count = UP.Count;
@@ -920,7 +920,7 @@ shouldPartialUnroll(const unsigned LoopSize, const unsigned TripCount,
     count = UP.MaxCount;
 
   LLVM_DEBUG(dbgs().indent(3)
-             << "partially unrolling with count: " << count << "\n");
+             << "Partially unrolling with count: " << count << "\n");
 
   return count;
 }
@@ -1105,8 +1105,8 @@ bool llvm::computeUnrollCount(
   UP.Runtime |= PragmaEnableUnroll || PragmaCount > 0 || UserUnrollCount;
   if (!UP.Runtime) {
     LLVM_DEBUG(dbgs().indent(2)
-               << "will not try to unroll loop with runtime trip count "
-               << "-unroll-runtime not given\n");
+               << "Will not try to unroll loop with runtime trip count "
+               << "because -unroll-runtime not given.\n");
     UP.Count = 0;
     return false;
   }
@@ -1148,7 +1148,7 @@ bool llvm::computeUnrollCount(
                   "unroll "
                   "count that divides the loop trip multiple of "
                << NV("TripMultiple", TripMultiple) << ".  Unrolling instead "
-               << NV("UnrollCount", UP.Count) << " time(s).";
+               << NV("UnrollCount", UP.Count) << " time(s)";
       });
   }
 
@@ -1159,7 +1159,7 @@ bool llvm::computeUnrollCount(
     UP.Count = MaxTripCount;
 
   LLVM_DEBUG(dbgs().indent(2)
-             << "runtime unrolling with count: " << UP.Count << "\n");
+             << "Runtime unrolling with count: " << UP.Count << "\n");
   if (UP.Count < 2)
     UP.Count = 0;
   return ExplicitUnroll;

--- a/llvm/test/Transforms/LoopUnroll/debug.ll
+++ b/llvm/test/Transforms/LoopUnroll/debug.ll
@@ -4,7 +4,7 @@
 
 ; CHECK-LABEL:Loop Unroll: F[pragma_full_unroll_unknown_tc] Loop %for.body
 ; CHECK-NEXT:Loop Size = 6
-; CHECK-NEXT:  will not try to unroll loop with runtime trip count -unroll-runtime not given
+; CHECK-NEXT:  Will not try to unroll loop with runtime trip count because -unroll-runtime not given.
 
 define i32 @pragma_full_unroll_unknown_tc(ptr %A, i32 %n) {
 entry:
@@ -28,7 +28,7 @@ exit:
 
 ; CHECK-LABEL:Loop Unroll: F[full_unroll_cost_exceeds] Loop %for.body
 ; CHECK-NEXT:Loop Size = 6
-; CHECK-NEXT:   will not try to unroll partially because -unroll-allow-partial not given
+; CHECK-NEXT:   Will not try to unroll partially because -unroll-allow-partial not given.
 
 define i32 @full_unroll_cost_exceeds(ptr %A) {
 entry:

--- a/llvm/test/Transforms/LoopUnroll/full-unroll-avoid-partial.ll
+++ b/llvm/test/Transforms/LoopUnroll/full-unroll-avoid-partial.ll
@@ -9,7 +9,7 @@
 
 ; LOOP-UNROLL-LABEL: Loop Unroll: F[pragma_unroll] Loop %for.body
 ; LOOP-UNROLL-NEXT: Loop Size = 9
-; LOOP-UNROLL-NEXT: runtime unrolling with count: 8
+; LOOP-UNROLL-NEXT: Runtime unrolling with count: 8
 ; LOOP-UNROLL-NEXT: Exiting block %for.body: TripCount=0, TripMultiple=1, BreakoutTrip=1
 ; LOOP-UNROLL-NEXT: Trying runtime unrolling on Loop:
 ; LOOP-UNROLL-NEXT: Loop at depth 1 containing: %for.body<header><latch><exiting>
@@ -18,7 +18,7 @@
 
 ; LOOP-UNROLL-FULL-LABEL: Loop Unroll: F[pragma_unroll] Loop %for.body
 ; LOOP-UNROLL-FULL-NEXT: Loop Size = 9
-; LOOP-UNROLL-FULL-NEXT:  runtime unrolling with count: 8
+; LOOP-UNROLL-FULL-NEXT:  Runtime unrolling with count: 8
 ; LOOP-UNROLL-FULL-NEXT: Not attempting partial/runtime unroll in FullLoopUnroll
 define void @pragma_unroll(ptr %queue, i32 %num_elements) {
 entry:

--- a/llvm/test/Transforms/LoopUnroll/guard-cost-for-unrolling.ll
+++ b/llvm/test/Transforms/LoopUnroll/guard-cost-for-unrolling.ll
@@ -9,7 +9,7 @@
 define void @test_guard_as_intrinsic(ptr %arr, i64 %n, i64 %bound) {
 ; CHECK-LABEL: Loop Unroll: F[test_guard_as_intrinsic] Loop %loop
 ; CHECK-NEXT:    Loop Size = 8
-; CHECK-NEXT:    runtime unrolling with count: 2
+; CHECK-NEXT:    Runtime unrolling with count: 2
 entry:
   br label %loop
 
@@ -31,7 +31,7 @@ exit:
 define void @test_guard_as_branch(ptr %arr, i64 %n, i64 %bound) {
 ; CHECK-LABEL: Loop Unroll: F[test_guard_as_branch] Loop %loop
 ; CHECK-NEXT:    Loop Size = 8
-; CHECK-NEXT:    runtime unrolling with count: 2
+; CHECK-NEXT:    Runtime unrolling with count: 2
 entry:
   br label %loop
 


### PR DESCRIPTION
## Summary
- NFC text-only changes to existing `LLVM_DEBUG` and ORE messages in `LoopUnrollPass.cpp`.
- Capitalize the first word of debug messages, add trailing periods, add "because" for readability, and remove a trailing period from one ORE remark to follow ORE conventions.

## Test plan
- [x] `llvm-lit llvm/test/Transforms/LoopUnroll/debug.ll` passes
- [x] `llvm-lit llvm/test/Transforms/LoopUnroll/full-unroll-avoid-partial.ll` passes
- [x] `llvm-lit llvm/test/Transforms/LoopUnroll/guard-cost-for-unrolling.ll` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)